### PR TITLE
[#15] 설정값 중 비밀값 처리 방식 수정

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,1 @@
-.database.env
+secret/

--- a/docker-compose-dev.yml
+++ b/docker-compose-dev.yml
@@ -4,8 +4,14 @@ services:
       context: ./database
     volumes:
       - double-entry-book-keeping-data:/var/lib/mysql:rw
-    env_file:
-      - .database.env
+    environment:
+      MYSQL_DATABASE: "double-entry-book-keeping"
+      MYSQL_USER: "user"
+      MYSQL_ROOT_DATABASE_FILE: /run/secrets/db_root_password
+      MYSQL_PASSWORD_FILE: /run/secrets/db_password
+    secrets:
+      - db_root_password
+      - db_password
     networks:
       - private
     healthcheck:
@@ -27,8 +33,8 @@ services:
     networks:
       - private
       - default
-    env_file:
-      - ./server/.env
+    secrets:
+      - config.yaml
     healthcheck:
       test: ["CMD-SHELL", "wget --spider -q http://server:3000/health || exit 1"]
       interval: 10s
@@ -56,7 +62,7 @@ services:
       retries: 3
       start_period: 5s
     env_file:
-      - ./client/.env
+      - ./env/development/.client.env
 
 
 volumes:
@@ -64,3 +70,11 @@ volumes:
 
 networks:
   private:
+
+secrets:
+  db_root_password:
+    file: ./secret/development/db_root_password.txt
+  db_password:
+    file: ./secret/development/db_password.txt
+  config.yaml:
+    file: ./secret/development/config.yaml

--- a/env/development/.client.env
+++ b/env/development/.client.env
@@ -1,0 +1,1 @@
+REACT_APP_API_BASE_URL=http://localhost:4000

--- a/server/package-lock.json
+++ b/server/package-lock.json
@@ -11,6 +11,7 @@
       "dependencies": {
         "@nestjs/axios": "^3.0.2",
         "@nestjs/common": "^10.0.0",
+        "@nestjs/config": "^3.2.3",
         "@nestjs/core": "^10.0.0",
         "@nestjs/jwt": "^10.2.0",
         "@nestjs/platform-express": "^10.0.0",
@@ -20,6 +21,7 @@
         "bcryptjs": "^2.4.3",
         "date-fns": "^3.6.0",
         "date-fns-tz": "^3.1.3",
+        "js-yaml": "^4.1.0",
         "lodash": "^4.17.21",
         "reflect-metadata": "^0.2.0",
         "rxjs": "^7.8.1"
@@ -31,6 +33,7 @@
         "@types/bcryptjs": "^2.4.6",
         "@types/express": "^4.17.17",
         "@types/jest": "^29.5.2",
+        "@types/js-yaml": "^4.0.9",
         "@types/lodash": "^4.17.7",
         "@types/node": "^20.3.1",
         "@types/supertest": "^6.0.0",
@@ -1737,6 +1740,21 @@
         }
       }
     },
+    "node_modules/@nestjs/config": {
+      "version": "3.2.3",
+      "resolved": "https://registry.npmjs.org/@nestjs/config/-/config-3.2.3.tgz",
+      "integrity": "sha512-p6yv/CvoBewJ72mBq4NXgOAi2rSQNWx3a+IMJLVKS2uiwFCOQQuiIatGwq6MRjXV3Jr+B41iUO8FIf4xBrZ4/w==",
+      "license": "MIT",
+      "dependencies": {
+        "dotenv": "16.4.5",
+        "dotenv-expand": "10.0.0",
+        "lodash": "4.17.21"
+      },
+      "peerDependencies": {
+        "@nestjs/common": "^8.0.0 || ^9.0.0 || ^10.0.0",
+        "rxjs": "^7.1.0"
+      }
+    },
     "node_modules/@nestjs/core": {
       "version": "10.3.10",
       "resolved": "https://registry.npmjs.org/@nestjs/core/-/core-10.3.10.tgz",
@@ -2281,6 +2299,13 @@
         "expect": "^29.0.0",
         "pretty-format": "^29.0.0"
       }
+    },
+    "node_modules/@types/js-yaml": {
+      "version": "4.0.9",
+      "resolved": "https://registry.npmjs.org/@types/js-yaml/-/js-yaml-4.0.9.tgz",
+      "integrity": "sha512-k4MGaQl5TGo/iipqb2UDG2UwjXziSWkh0uysQelTlJpX1qGlpUZYm8PnO4DxG1qBomtJUdYJ6qR6xdIah10JLg==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@types/json-schema": {
       "version": "7.0.15",
@@ -2952,8 +2977,7 @@
     "node_modules/argparse": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
-      "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
-      "dev": true
+      "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q=="
     },
     "node_modules/array-flatten": {
       "version": "1.1.1",
@@ -4059,6 +4083,27 @@
       },
       "engines": {
         "node": ">=6.0.0"
+      }
+    },
+    "node_modules/dotenv": {
+      "version": "16.4.5",
+      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-16.4.5.tgz",
+      "integrity": "sha512-ZmdL2rui+eB2YwhsWzjInR8LldtZHGDoQ1ugH85ppHKwpUHL7j7rN0Ti9NCnGiQbhaZ11FpR+7ao1dNsmduNUg==",
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://dotenvx.com"
+      }
+    },
+    "node_modules/dotenv-expand": {
+      "version": "10.0.0",
+      "resolved": "https://registry.npmjs.org/dotenv-expand/-/dotenv-expand-10.0.0.tgz",
+      "integrity": "sha512-GopVGCpVS1UKH75VKHGuQFqS1Gusej0z4FyQkPdwjil2gNIv+LNsqBlboOzpJFZKVT95GkCyWJbBSdFEFUWI2A==",
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=12"
       }
     },
     "node_modules/eastasianwidth": {
@@ -6331,7 +6376,7 @@
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.0.tgz",
       "integrity": "sha512-wpxZs9NoxZaJESJGIZTyDEaYpl0FKSA+FB9aJiyemKhMwkxQg63h4T1KJgUGHpTqPDNRcmmYLugrRjJlBtWvRA==",
-      "dev": true,
+      "license": "MIT",
       "dependencies": {
         "argparse": "^2.0.1"
       },

--- a/server/package.json
+++ b/server/package.json
@@ -22,6 +22,7 @@
   "dependencies": {
     "@nestjs/axios": "^3.0.2",
     "@nestjs/common": "^10.0.0",
+    "@nestjs/config": "^3.2.3",
     "@nestjs/core": "^10.0.0",
     "@nestjs/jwt": "^10.2.0",
     "@nestjs/platform-express": "^10.0.0",
@@ -31,6 +32,7 @@
     "bcryptjs": "^2.4.3",
     "date-fns": "^3.6.0",
     "date-fns-tz": "^3.1.3",
+    "js-yaml": "^4.1.0",
     "lodash": "^4.17.21",
     "reflect-metadata": "^0.2.0",
     "rxjs": "^7.8.1"
@@ -42,6 +44,7 @@
     "@types/bcryptjs": "^2.4.6",
     "@types/express": "^4.17.17",
     "@types/jest": "^29.5.2",
+    "@types/js-yaml": "^4.0.9",
     "@types/lodash": "^4.17.7",
     "@types/node": "^20.3.1",
     "@types/supertest": "^6.0.0",

--- a/server/src/app.module.ts
+++ b/server/src/app.module.ts
@@ -3,9 +3,10 @@ import { AppController } from './app.controller';
 import { AppService } from './app.service';
 import { HealthModule } from './health/health.module';
 import { AuthModule } from './auth/auth.module';
+import { ConfigModule } from './config/config.module';
 
 @Module({
-  imports: [HealthModule, AuthModule],
+  imports: [ConfigModule, HealthModule, AuthModule],
   controllers: [AppController],
   providers: [AppService],
 })

--- a/server/src/auth/auth.controller.ts
+++ b/server/src/auth/auth.controller.ts
@@ -13,10 +13,14 @@ import { AuthService } from './auth.service';
 import { Prisma } from '@prisma/client';
 import { Request, Response } from 'express';
 import { AuthGuard } from './auth.guard';
+import { ConfigService } from 'src/config/config.service';
 
 @Controller('auth')
 export class AuthController {
-  constructor(private readonly authService: AuthService) {}
+  constructor(
+    private readonly authService: AuthService,
+    private readonly configService: ConfigService,
+  ) {}
 
   @HttpCode(HttpStatus.CREATED)
   @Post('signup')
@@ -28,9 +32,9 @@ export class AuthController {
 
     response.cookie('jwt', access_token, {
       httpOnly: true,
-      secure: process.env.NODE_ENV === 'production',
+      secure: this.configService.getEnvironment() === 'production',
       sameSite: 'strict',
-      maxAge: 60 * 1000,
+      maxAge: this.configService.getJwtConfig().cookie.maxAge,
     });
 
     return { message };
@@ -46,9 +50,9 @@ export class AuthController {
 
     response.cookie('jwt', access_token, {
       httpOnly: true,
-      secure: process.env.NODE_ENV === 'production',
+      secure: this.configService.getEnvironment() === 'production',
       sameSite: 'strict',
-      maxAge: 60 * 1000,
+      maxAge: this.configService.getJwtConfig().cookie.maxAge,
     });
 
     return { message };

--- a/server/src/auth/auth.guard.ts
+++ b/server/src/auth/auth.guard.ts
@@ -6,10 +6,14 @@ import {
 } from '@nestjs/common';
 import { JwtService } from '@nestjs/jwt';
 import { Request } from 'express';
+import { ConfigService } from 'src/config/config.service';
 
 @Injectable()
 export class AuthGuard implements CanActivate {
-  constructor(private jwtService: JwtService) {}
+  constructor(
+    private jwtService: JwtService,
+    private configService: ConfigService,
+  ) {}
 
   async canActivate(context: ExecutionContext): Promise<boolean> {
     const request = context.switchToHttp().getRequest();
@@ -19,9 +23,10 @@ export class AuthGuard implements CanActivate {
     if (!token) {
       throw new UnauthorizedException();
     }
+
     try {
       const payload = await this.jwtService.verifyAsync(token, {
-        secret: process.env.JWT_SECRET,
+        secret: this.configService.getJwtConfig().secret,
       });
 
       request['user'] = payload;

--- a/server/src/auth/auth.module.ts
+++ b/server/src/auth/auth.module.ts
@@ -3,15 +3,22 @@ import { UserModule } from 'src/user/user.module';
 import { AuthService } from './auth.service';
 import { JwtModule } from '@nestjs/jwt';
 import { AuthController } from './auth.controller';
+import { ConfigModule } from 'src/config/config.module';
+import { ConfigService } from 'src/config/config.service';
 
 @Module({
   imports: [
     UserModule,
-    JwtModule.register({
-      secret: process.env.JWT_SECRET,
-      signOptions: {
-        expiresIn: '60s',
-      },
+    ConfigModule,
+    JwtModule.registerAsync({
+      imports: [ConfigModule],
+      inject: [ConfigService],
+      useFactory: async (configService: ConfigService) => ({
+        secret: configService.getJwtConfig().secret,
+        signOptions: {
+          expiresIn: configService.getJwtConfig().expiresIn,
+        },
+      }),
     }),
   ],
   controllers: [AuthController],

--- a/server/src/config/config.module.ts
+++ b/server/src/config/config.module.ts
@@ -1,0 +1,28 @@
+import { Module } from '@nestjs/common';
+import { ConfigModule as NestConfigModule } from '@nestjs/config';
+import { readFileSync } from 'fs';
+import * as yaml from 'js-yaml';
+import { ConfigService } from './config.service';
+import { ConfigSchema } from './types';
+
+@Module({
+  imports: [
+    NestConfigModule.forRoot({
+      load: [
+        (): ConfigSchema => {
+          const yamlFilePath = '/run/secrets/config.yaml';
+          const fileContent = readFileSync(yamlFilePath, 'utf8');
+          const config = yaml.load(fileContent) as ConfigSchema;
+
+          // prisma는 환경 변수로만 데이터베이스 url을 받을 수 있음
+          process.env.DATABASE_URL = config.database.url;
+
+          return config;
+        },
+      ],
+    }),
+  ],
+  providers: [ConfigService],
+  exports: [ConfigService],
+})
+export class ConfigModule {}

--- a/server/src/config/config.service.ts
+++ b/server/src/config/config.service.ts
@@ -1,0 +1,32 @@
+import { ConfigService as NestConfigService } from '@nestjs/config';
+import {
+  ClientConfig,
+  ConfigSchema,
+  DatabaseConfig,
+  Environment,
+  JwtConfig,
+} from './types';
+import { Injectable } from '@nestjs/common';
+
+@Injectable()
+export class ConfigService {
+  constructor(
+    private readonly nestConfigService: NestConfigService<ConfigSchema>,
+  ) {}
+
+  getEnvironment(): Environment {
+    return this.nestConfigService.get<Environment>('environment');
+  }
+
+  getDatabaseConfig(): DatabaseConfig {
+    return this.nestConfigService.get<DatabaseConfig>('database');
+  }
+
+  getJwtConfig(): JwtConfig {
+    return this.nestConfigService.get<JwtConfig>('jwt');
+  }
+
+  getClientConfig(): ClientConfig {
+    return this.nestConfigService.get<ClientConfig>('client');
+  }
+}

--- a/server/src/config/types.ts
+++ b/server/src/config/types.ts
@@ -1,0 +1,26 @@
+export interface DatabaseConfig {
+  url: string;
+}
+
+export interface JwtCookieConfig {
+  maxAge: number;
+}
+
+export interface JwtConfig {
+  secret: string;
+  expiresIn: string;
+  cookie: JwtCookieConfig;
+}
+
+export interface ClientConfig {
+  host: string;
+}
+
+export type Environment = 'development' | 'production';
+
+export interface ConfigSchema {
+  environment: Environment;
+  database: DatabaseConfig;
+  jwt: JwtConfig;
+  client: ClientConfig;
+}

--- a/server/src/main.ts
+++ b/server/src/main.ts
@@ -1,11 +1,16 @@
 import { NestFactory } from '@nestjs/core';
 import { AppModule } from './app.module';
+import { ConfigService } from './config/config.service';
 
 async function bootstrap() {
   const app = await NestFactory.create(AppModule);
 
+  const configService = app.get<ConfigService>(ConfigService);
+
+  const clientConfig = configService.getClientConfig();
+
   app.enableCors({
-    origin: process.env.CLIENT_HOST,
+    origin: clientConfig.host,
     // 쿠키 허용을 위함
     credentials: true,
   });


### PR DESCRIPTION
- 배경: 이전에는 비밀값을 환경변수로 주입했으나 환경변수는 프로세스를 조회하는 시스템 명령어에 쉽게 노출되고, 이로 인해 로그에 의도치 않게 노출될 확률이 있음. 따라서 보안상 중요한 설정값은 파일로 주입하여 이러한 사고를 예방하고자 함.
1. 데이터베이스 설정값 주입 방식 변경 비밀번호와 관련된 값은 파일로 주입이 가능
2. 백엔드 설정값 주입 방식 변경 yaml파일을 주입하여 애플리케이션에서 해당 파일을 설정값으로 사용하도록 구현
3. 프론트엔드 설정값 주입 방식 변경 어차피 프론트엔드의 설정값은 SSR이 아닌 이상 다 노출되기 마련이라 env 파일로 오픈하고 주입